### PR TITLE
fix(packaging): Configure build process and packaging. This change fi…

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,10 @@
+declare const API: {
+    play: (base64: string, mimeType?: string) => Promise<any>;
+    pause: () => Promise<any>;
+    resume: () => Promise<any>;
+    stop: () => Promise<any>;
+    setVolume: (v: number) => Promise<any>;
+    unload: () => Promise<any>;
+    addListener: (cb: (event: any) => void) => () => void;
+};
+export default API;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,22 @@
+import { NativeModules, NativeEventEmitter } from "react-native";
+const { Base64Audio } = NativeModules;
+const emitter = Base64Audio ? new NativeEventEmitter(Base64Audio) : null;
+const API = {
+    play: async (base64, mimeType = "audio/mpeg") => {
+        if (!Base64Audio)
+            throw new Error("Native module Base64Audio not found");
+        return Base64Audio.play(base64, mimeType);
+    },
+    pause: async () => Base64Audio?.pause(),
+    resume: async () => Base64Audio?.resume(),
+    stop: async () => Base64Audio?.stop(),
+    setVolume: async (v) => Base64Audio?.setVolume(v),
+    unload: async () => Base64Audio?.unload(),
+    addListener: (cb) => {
+        if (!emitter)
+            return () => { };
+        const sub = emitter.addListener("Base64AudioEvent", cb);
+        return () => sub.remove();
+    },
+};
+export default API;

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "react-native-base64-audio-player",
   "version": "1.0.0",
   "description": "Native module to play base64 audio in memory for React Native (Android & iOS)",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "lint": "eslint . --ext .ts,.tsx"
+    "lint": "eslint . --ext .ts,.tsx",
+    "prepare": "tsc"
   },
   "peerDependencies": {
     "react": ">=18.0.0",
@@ -35,7 +36,7 @@
   "license": "MIT",
   "type": "module",
   "files": [
-    "src",
+    "dist",
     "android",
     "ios",
     "react-native-base64-audio-player.podspec"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,9 @@
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
     "allowSyntheticDefaultImports": true,
-    "outDir": "lib"
+    "outDir": "dist",
+    "declaration": true
   },
-  "include": ["src/**/*"],
+  "include": ["src"],
   "exclude": ["node_modules", "android", "ios"]
 }


### PR DESCRIPTION
…xes an issue where the package could not be installed from GitHub because it was not being compiled from TypeScript to JavaScript before being packed. This commit introduces a build step that compiles the TypeScript source to a `dist` directory and updates `package.json` to correctly point to the compiled files. A `prepare` script has been added to ensure the build is run automatically before the package is packed.