### PR TITLE
fix(android): Remove type:module from package.json to fix build. This…

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,6 +1,6 @@
-import tseslint from 'typescript-eslint';
+const tseslint = require('typescript-eslint');
 
-export default tseslint.config(
+module.exports = tseslint.config(
   {
     ignores: ["node_modules", "android", "ios", "babel.config.js"],
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "author": "Antonio Gil",
   "license": "MIT",
-  "type": "module",
   "files": [
     "dist",
     "android",


### PR DESCRIPTION
… change removes the `"type": "module"` field from `package.json`. This field was causing the React Native Android build to fail because the CLI tools were not able to correctly parse the package configuration. The ESLint configuration has been updated to use CommonJS (`.cjs`) to ensure the development environment remains functional after this change.